### PR TITLE
[#118] Update print_slips for modern Koha

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/RapidoILL/APIController.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/RapidoILL/APIController.pm
@@ -245,14 +245,14 @@ sub get_print_slip {
         }
 
         my $slip = C4::Letters::GetPreparedLetter(
-            module                 => 'circulation',        # FIXME: should be 'ill' in 20.11+
+            module                 => 'ill',
             letter_code            => $print_slip_id,
             branchcode             => $req->branchcode,
             message_transport_type => 'print',
             lang                   => $req->patron->lang,
             tables                 => {
 
-                # illrequests => $req->illrequest_id, # FIXME: should be used in 20.11+
+                illrequests => $req->illrequest_id, 
                 borrowers => $req->borrowernumber,
                 biblio    => $req->biblio_id,
                 item      => $item_id,
@@ -260,7 +260,6 @@ sub get_print_slip {
             },
             substitute => {
                 illrequestattributes => $illrequestattributes,
-                illrequest           => $req->unblessed,         # FIXME: should be removed in 20.11+
                 ill_bib_title        => $title  ? $title->value  : '',
                 ill_bib_author       => $author ? $author->value : '',
                 ill_full_metadata    => $metastring


### PR DESCRIPTION
-Followed the #todo and #fixme comments from changes in past koha versions to restore this functionality.

This restores the ability to use /api/v1/contrib/innreach/koha/ill_requests/{requestid}/print_slips/{letter_code} to create slips.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update print slip generation to use the modern Koha Ill system by:
- Changing the module from 'circulation' to 'ill' when preparing the letter.
- Including illrequests in the data tables passed to the template.
- Removing the illrequest substitution field that was previously present.

### Why are these changes being made?

Align with Koha 20.11+ expectations for ILL print slips and simplify the template data by removing deprecated illrequest substitution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->